### PR TITLE
Add GPIO3 (Raspberry Pi Bootup Pin) to selection

### DIFF
--- a/octoprint_GPIOShutdown/templates/GPIOShutdown_settings.jinja2
+++ b/octoprint_GPIOShutdown/templates/GPIOShutdown_settings.jinja2
@@ -5,6 +5,7 @@
         <div class="controls" data-toggle="tooltip" title="{{ _('Which Raspberry Pi GPIO pin (BCM Mode) your shutdown switch is attached to.') }}">
 			<select data-bind="value: settings.plugins.GPIOShutdown.pin_shutdown">
 				<option value="-1">Disabled</option>
+				<option value="3">GPIO 3</option>
 				<option value="4">GPIO 4</option>
 				<option value="5">GPIO 5</option>
 				<option value="6">GPIO 6</option>


### PR DESCRIPTION
Fixes https://github.com/fmalekpour/OctoPrint-Gpioshutdown/issues/3