### PR TITLE
Enable GPIO 3

### DIFF
--- a/octoprint_GPIOShutdown/templates/GPIOShutdown_settings.jinja2
+++ b/octoprint_GPIOShutdown/templates/GPIOShutdown_settings.jinja2
@@ -5,6 +5,7 @@
         <div class="controls" data-toggle="tooltip" title="{{ _('Which Raspberry Pi GPIO pin (BCM Mode) your shutdown switch is attached to.') }}">
 			<select data-bind="value: settings.plugins.GPIOShutdown.pin_shutdown">
 				<option value="-1">Disabled</option>
+				<option value="3">GPIO 3</option>
 				<option value="4">GPIO 4</option>
 				<option value="5">GPIO 5</option>
 				<option value="6">GPIO 6</option>


### PR DESCRIPTION
This fixes #3 by allowing you to choose GPIO3 from the dropdown. This is only implemented for the start/stop button (not for the status LED) because GPIO3 also serves as the wake/boot pin (see https://www.embeddedcomputing.com/technology/open-source/development-kits/raspberry-pi-power-up-and-shutdown-with-a-physical-button for an example).

Tested on my Raspberry Pi 3, testing can be done through the Plugin Manager (enter `https://github.com/peterrus/OctoPrint-Gpioshutdown/archive/refs/heads/feature/enable-gpio4.zip`) until this PR is closed and merged into upstream.