### PR TITLE
Fixed typo (Add holdtime)

### DIFF
--- a/octoprint_GPIOShutdown/__init__.py
+++ b/octoprint_GPIOShutdown/__init__.py
@@ -101,7 +101,7 @@ class GpioshutdownPlugin(
 	def sensor_callback(self, _):
 		sleep(self.bounce/1000)
 		if GPIO.input(self.pin_shutdown)==1:
-			self._logger.info("GPIO is '{0}' after Holdtime. NO shutdown".format(GPIO.input(self.pin_shutdown_)))
+			self._logger.info("GPIO is '{0}' after Holdtime. NO shutdown".format(GPIO.input(self.pin_shutdown)))
 			return
 		if self.activated==1:
 			return

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ plugin_package = "octoprint_GPIOShutdown"
 plugin_name = "OctoPrint-Gpioshutdown"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.0.4"
+plugin_version = "1.0.5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Found out a situation which leads into an uncaught exception. This appears in case that the shutdown button is not active after the debounce time.